### PR TITLE
Fixes issue when excluding several files/folders.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = {
           .destination(destination);
 
         if (this.readConfig('exclude')){
-          rsync.set('exclude', this.readConfig('exclude'));
+          rsync.exclude(this.readConfig('exclude'));
         }
 
         if (this.readConfig('displayCommands')){


### PR DESCRIPTION
Calling `exclude` in a Rsync instance instead of setting the exclude
property allows to pass an array of exclude patterns to the rsync
command.