### PR TITLE
Move ember-cli-babel to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "2.3.0",
     "ember-cli-app-version": "^1.0.0",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -45,7 +46,6 @@
     "ember-cli-deploy-plugin"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "^0.2.2",
     "rsync": "^0.4.0"
   },


### PR DESCRIPTION
Unnecessary since `app` and `addon` is empty and most probably will stay empty.